### PR TITLE
Feature: Cancel a User

### DIFF
--- a/WokebucksBot/Bot/CommandModules/BalanceModule.cs
+++ b/WokebucksBot/Bot/CommandModules/BalanceModule.cs
@@ -245,7 +245,7 @@ namespace Swamp.WokebucksBot.Bot.CommandModules
 				targetData.UpdateUsernameAndAddToBalance(amount, target.GetFullUsername());
 				targetData.AddTransaction(Context.User.GetFullUsername(), reason, amount);
 
-				// Update leaderboard
+				// Update leaderboard for all guilds:
 				leaderboard.UpdateLeaderboard(Context.Guild.Id.ToString(), target, targetData.Balance);
 
 				// Add $1 to lottery pool:

--- a/WokebucksBot/Bot/CommandModules/BettingModule.cs
+++ b/WokebucksBot/Bot/CommandModules/BettingModule.cs
@@ -31,7 +31,7 @@ namespace Swamp.WokebucksBot.Bot.CommandModules
 			var embedBuilder = new EmbedBuilder();
 			if (string.IsNullOrWhiteSpace(bettingReason))
 			{
-				await FollowupWithFormattedError(Context.User, embedBuilder, $"You must provide a reason for the bet, since this will be the name of the bet.");
+				await FollowupWithFormattedError(Context.User, embedBuilder, "You must provide a reason for the bet, since this will be the name of the bet.");
 				_logger.LogError($"<{{{CommandName}}}> command failed for user <{{{UserIdKey}}}> since user did not provide a bet reason.", "startbet", Context.User.GetFullUsername());
 				return;
 			}
@@ -39,7 +39,7 @@ namespace Swamp.WokebucksBot.Bot.CommandModules
 			List<string> options = optionsString.Split(',').ToList();
 			if (options.Count() <= 1 || options.Count() > 6)
             {
-				await FollowupWithFormattedError(Context.User, embedBuilder, $"You have to provide at least two (and no more than six) options to start a bet.");
+				await FollowupWithFormattedError(Context.User, embedBuilder, "You have to provide at least two (and no more than six) options to start a bet.");
 				_logger.LogError($"<{{{CommandName}}}> command failed for user <{{{UserIdKey}}}> since user did not provide enough options for bet, or provided too many.", "startbet", Context.User.GetFullUsername());
 				return;
 			}
@@ -54,7 +54,7 @@ namespace Swamp.WokebucksBot.Bot.CommandModules
 			}
 			catch (Exception e)
             {
-				await FollowupWithFormattedError(Context.User, embedBuilder, $"You have to provide text for all options.");
+				await FollowupWithFormattedError(Context.User, embedBuilder, "You have to provide text for all options.");
 				_logger.LogError(e, $"<{{{CommandName}}}> command failed for user <{{{UserIdKey}}}> since user provided a null or empty option.", "startbet", Context.User.GetFullUsername());
 				return;
 			}
@@ -66,21 +66,20 @@ namespace Swamp.WokebucksBot.Bot.CommandModules
 			var menuBuilder = new SelectMenuBuilder()
 									.WithPlaceholder("Select an option to place your bet on.")
 									.WithCustomId(bet.ID);
-			int count = 1;
+
 			foreach (string option in bet.OptionTotals.Keys)
             {
 				// Display option, underlying value is combined bet ID and option ID
 				menuBuilder.AddOption(option, new Bet.BetOptionKey(bet.ID, option, Context.Guild.Id.ToString()).FullKey);
-				count++;
             }
 
 			var builder = new ComponentBuilder()
 				.WithSelectMenu(menuBuilder);
 
 			embedBuilder.WithColor(Color.Gold);
-			embedBuilder.WithTitle($"Starting Bet");
-			embedBuilder.AddField("Bet", $"{bet.Reason}");
-			embedBuilder.AddField("Started By", $"{Context.User.GetFullUsername()}");
+			embedBuilder.WithTitle("Starting Bet");
+			embedBuilder.AddField("Bet", bet.Reason);
+			embedBuilder.AddField("Started By", Context.User.GetFullUsername());
 			embedBuilder.WithFooter($"{Context.User.GetFullUsername()}'s Bet handled by Wokebucks");
 			embedBuilder.WithUrl("https://github.com/chicklightning/WokebucksBot");
 			embedBuilder.WithCurrentTimestamp();

--- a/WokebucksBot/Bot/CommandModules/CancelModule.cs
+++ b/WokebucksBot/Bot/CommandModules/CancelModule.cs
@@ -3,12 +3,6 @@ using Discord.Commands;
 using Discord.WebSocket;
 using Swamp.WokebucksBot.Bot.Extensions;
 using Swamp.WokebucksBot.CosmosDB;
-using Swamp.WokebucksBot.CosmosDB.Models.Users;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace Swamp.WokebucksBot.Bot.CommandModules
 {
@@ -72,7 +66,6 @@ namespace Swamp.WokebucksBot.Bot.CommandModules
 			}
 
 			// It's been at least two days, so overwrite this ticket:
-			ticket = new CancelTicket(targetUser, Context.User, reason);
 			Task<UserData?> fetchTargetData = _documentClient.GetDocumentAsync<UserData>(targetUser.Id.ToString());
 			Task<UserData?> fetchInitiatorData = _documentClient.GetDocumentAsync<UserData>(Context.User.Id.ToString());
 
@@ -81,7 +74,8 @@ namespace Swamp.WokebucksBot.Bot.CommandModules
 			UserData initiatorData = await fetchInitiatorData ?? new UserData(Context.User);
 
 			// Add ticket to both users:
-			ticket = new CancelTicket(targetUser, Context.User, reason);
+			var reducedReason = reason.Length > 200 ? reason.Substring(0, 200) : reason;
+			ticket = new CancelTicket(targetUser, Context.User, reducedReason);
 			initiatorData.AddCreatedTicket(ticket);
 			targetData.AddCancelTicket(ticket);
 
@@ -103,7 +97,7 @@ namespace Swamp.WokebucksBot.Bot.CommandModules
 			embedBuilder.WithColor(Color.Red)
 						.WithTitle($"{Context.User.GetFullUsername()} Submitted a Ticket to Cancel {targetUser.GetFullUsername()}")
 						.WithDescription("If this request gets at least six (6) votes in favor of cancelling, the target user will be cancelled.")
-						.WithFooter($"{Context.User.GetFullUsername()}'s Cancellation Request handled by Wokebucks")
+						.WithFooter($"{Context.User.GetFullUsername()}'s Cancel Ticket Request handled by Wokebucks")
 						.WithUrl("https://github.com/chicklightning/WokebucksBot")
 						.WithCurrentTimestamp();
 
@@ -114,14 +108,94 @@ namespace Swamp.WokebucksBot.Bot.CommandModules
 		[Summary("See all of your current tickets.")]
 		public async Task GetTicketsAsync()
 		{
+			_logger.LogInformation($"<{{{CommandName}}}> command invoked by user <{{{UserIdKey}}}>.", "tickets", Context.User.GetFullUsername());
 
+			UserData user = await _documentClient.GetDocumentAsync<UserData>(Context.User.Id.ToString()) ?? new UserData(Context.User);
+
+			var embedBuilder = new EmbedBuilder();
+			if (user.CreatedTickets.Count == 0)
+            {
+				embedBuilder.WithColor(Color.Teal);
+				embedBuilder.WithTitle($"Cancel Tickets Opened by {Context.User.GetFullUsername()}");
+				embedBuilder.WithDescription("You have not opened any cancel tickets.");
+				embedBuilder.WithFooter($"{Context.User.GetFullUsername()}'s Cancel Tickets provided by Wokebucks");
+				embedBuilder.WithUrl("https://github.com/chicklightning/WokebucksBot");
+				embedBuilder.WithCurrentTimestamp();
+
+				await ReplyAsync("", false, embed: embedBuilder.Build());
+			}
+
+			// Return multiple options for user to select, along with bet amount
+			var menuBuilder = new SelectMenuBuilder()
+									.WithPlaceholder("Select a ticket you would like to view.")
+									.WithCustomId("cancel");
+
+			foreach (var ticketPair in user.CreatedTickets)
+			{
+				// Display option, underlying value is combined bet ID and option ID
+				menuBuilder.AddOption(ticketPair.Value, ticketPair.Key);
+			}
+
+			var builder = new ComponentBuilder()
+				.WithSelectMenu(menuBuilder);
+
+			embedBuilder.WithColor(Color.Teal);
+			embedBuilder.WithTitle($"Cancel Tickets Opened by {Context.User.GetFullUsername()}");
+			embedBuilder.WithDescription("Select an option below to view more information on a cancel ticket.");
+			embedBuilder.WithFooter($"{Context.User.GetFullUsername()}'s Cancel Tickets provided by Wokebucks");
+			embedBuilder.WithUrl("https://github.com/chicklightning/WokebucksBot");
+			embedBuilder.WithCurrentTimestamp();
+
+			await ReplyAsync("", embed: embedBuilder.Build(), components: builder.Build());
+
+			_logger.LogInformation($"<{{{CommandName}}}> command successfully completed by user <{{{UserIdKey}}}>.", "tickets", Context.User.GetFullUsername());
 		}
 
 		[Command("complaints")]
 		[Summary("See all current tickets against you.")]
 		public async Task GetComplaintsAsync()
 		{
+			_logger.LogInformation($"<{{{CommandName}}}> command invoked by user <{{{UserIdKey}}}>.", "complaints", Context.User.GetFullUsername());
 
+			UserData user = await _documentClient.GetDocumentAsync<UserData>(Context.User.Id.ToString()) ?? new UserData(Context.User);
+
+			var embedBuilder = new EmbedBuilder();
+			if (user.CancelTickets.Count == 0)
+			{
+				embedBuilder.WithColor(Color.Teal);
+				embedBuilder.WithTitle($"Cancel Tickets Opened on {Context.User.GetFullUsername()}");
+				embedBuilder.WithDescription("Nobody has opened any cancel tickets on you. That's pretty woke!");
+				embedBuilder.WithFooter($"{Context.User.GetFullUsername()}'s Cancel Tickets provided by Wokebucks");
+				embedBuilder.WithUrl("https://github.com/chicklightning/WokebucksBot");
+				embedBuilder.WithCurrentTimestamp();
+
+				await ReplyAsync("", false, embed: embedBuilder.Build());
+			}
+
+			// Return multiple options for user to select, along with bet amount
+			var menuBuilder = new SelectMenuBuilder()
+									.WithPlaceholder("Select a ticket you would like to view.")
+									.WithCustomId("cancel");
+
+			foreach (var ticketPair in user.CancelTickets)
+			{
+				// Display option, underlying value is combined bet ID and option ID
+				menuBuilder.AddOption(ticketPair.Value, ticketPair.Key);
+			}
+
+			var builder = new ComponentBuilder()
+				.WithSelectMenu(menuBuilder);
+
+			embedBuilder.WithColor(Color.Teal);
+			embedBuilder.WithTitle($"Cancel Tickets Opened on {Context.User.GetFullUsername()}");
+			embedBuilder.WithDescription("Select an option below to view more information on a cancel ticket.");
+			embedBuilder.WithFooter($"{Context.User.GetFullUsername()}'s Cancel Tickets provided by Wokebucks");
+			embedBuilder.WithUrl("https://github.com/chicklightning/WokebucksBot");
+			embedBuilder.WithCurrentTimestamp();
+
+			await ReplyAsync("", embed: embedBuilder.Build(), components: builder.Build());
+
+			_logger.LogInformation($"<{{{CommandName}}}> command successfully completed by user <{{{UserIdKey}}}>.", "complaints", Context.User.GetFullUsername());
 		}
 
 		private async Task<bool> ReactIfSelfWhereNotAllowedAsync(IApplication application, SocketUser target, SocketUserMessage userMessage)
@@ -136,7 +210,7 @@ namespace Swamp.WokebucksBot.Bot.CommandModules
 				embedBuilder.WithUrl("https://github.com/chicklightning/WokebucksBot");
 				embedBuilder.WithCurrentTimestamp();
 
-				await ReplyAsync($"", false, embed: embedBuilder.Build());
+				await ReplyAsync("", false, embed: embedBuilder.Build());
 
 				var emote = _discordSocketClient.Guilds
 							.Where(x => x.Name == "The Swamp")

--- a/WokebucksBot/Bot/CommandModules/CancelModule.cs
+++ b/WokebucksBot/Bot/CommandModules/CancelModule.cs
@@ -1,0 +1,163 @@
+﻿using Discord;
+using Discord.Commands;
+using Discord.WebSocket;
+using Swamp.WokebucksBot.Bot.Extensions;
+using Swamp.WokebucksBot.CosmosDB;
+using Swamp.WokebucksBot.CosmosDB.Models.Users;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Swamp.WokebucksBot.Bot.CommandModules
+{
+	public class CancelModule : ModuleBase<SocketCommandContext>
+	{
+		private const string CommandName = "CommandName";
+		private const string UserIdKey = "UserId";
+		private const string TargetUserIdKey = "TargetUserId";
+
+		private readonly ILogger<CancelModule> _logger;
+		private readonly CosmosDBClient _documentClient;
+		private readonly DiscordSocketClient _discordSocketClient;
+
+		public CancelModule(ILogger<CancelModule> logger, DiscordSocketClient discordSocketClient, CosmosDBClient docClient)
+		{
+			_logger = logger;
+			_discordSocketClient = discordSocketClient;
+			_documentClient = docClient;
+		}
+
+		[Command("cancel")]
+		[Summary("Puts up a vote for a user to be canceled (doubles a negative balance or sets a positive balance to 0).")]
+		public async Task CancelUserAsync(
+			[Summary("The reason you are canceling this user.")]
+			string reason,
+			[Summary("The user you want to cancel.")]
+			SocketUser? target = null)
+		{
+			_logger.LogInformation($"<{{{CommandName}}}> command invoked by user <{{{UserIdKey}}}>.", "cancel", Context.User.GetFullUsername());
+
+			var embedBuilder = new EmbedBuilder();
+			if (string.IsNullOrWhiteSpace(reason))
+            {
+				await RespondWithFormattedError(embedBuilder, "You have to provide a reason for cancellation.");
+				_logger.LogError($"<{{{CommandName}}}> command failed for user <{{{UserIdKey}}}> since they failed to provide a reason", "cancel", Context.User.GetFullUsername());
+				return;
+			}
+
+			SocketUser? targetUser = target ?? Context.Message.MentionedUsers.FirstOrDefault();
+			if (targetUser is null)
+			{
+				await RespondWithFormattedError(embedBuilder, "You have to mention a user in order to cancel them.");
+				_logger.LogError($"<{{{CommandName}}}> command failed for user <{{{UserIdKey}}}> targeting unknown user.", "cancel", Context.User.GetFullUsername());
+				return;
+			}
+
+			IApplication application = await Context.Client.GetApplicationInfoAsync().ConfigureAwait(continueOnCapturedContext: false);
+			if (await ReactIfSelfWhereNotAllowedAsync(application, targetUser, Context.Message))
+			{
+				return;
+			}
+
+			// See if user has a current ticket against this user already:
+			UserData targetData = await _documentClient.GetDocumentAsync<UserData>(targetUser.Id.ToString()) ?? new UserData(targetUser);
+			if (targetData.CancelTickets.ContainsKey(CancelTicket.CreateGuidFromTicketInitiatorAndTarget(Context.User.Id.ToString(), targetUser.Id.ToString())))
+            {
+				await RespondWithFormattedError(embedBuilder, "You already have an active cancellation ticket open for this user!");
+				_logger.LogError($"<{{{CommandName}}}> command failed for user <{{{UserIdKey}}}> since open ticket already exists against target user <{targetUser.GetFullUsername()}>.", "cancel", Context.User.GetFullUsername());
+				return;
+			}
+			else
+            {
+				UserData initiatorData = await _documentClient.GetDocumentAsync<UserData>(Context.User.Id.ToString()) ?? new UserData(Context.User);
+
+				// Add ticket to both users:
+				var ticket = new CancelTicket(targetUser, Context.User, reason);
+				initiatorData.AddCreatedTicket(ticket);
+				targetData.AddCancelTicket(ticket);
+
+				Task writeTicketTask = _documentClient.UpsertDocumentAsync<CancelTicket>(ticket);
+				Task writeInitiatorTask = _documentClient.UpsertDocumentAsync<UserData>(initiatorData);
+				Task writeTargetTask = _documentClient.UpsertDocumentAsync<UserData>(targetData);
+
+				await Task.WhenAll(writeTicketTask, writeInitiatorTask, writeTargetTask);
+
+				var ticketEmoji = new Emoji("\uD83D\uDEAB");
+				var buttonBuilder = new ButtonBuilder()
+											.WithEmote(ticketEmoji)
+											.WithLabel("Vote to Cancel")
+											.WithCustomId($"cancel{ticket.ID}")
+											.WithStyle(ButtonStyle.Danger);
+				var componentBuilder = new ComponentBuilder()
+											.WithButton(buttonBuilder);
+
+				embedBuilder.WithColor(Color.Red)
+							.WithTitle($"{Context.User.GetFullUsername()} Submitted a Ticket to Cancel {targetUser.GetFullUsername()}")
+							.WithDescription("If this request gets at least six (6) votes in favor of cancelling, the target user will be cancelled.")
+							.WithFooter($"{Context.User.GetFullUsername()}'s Cancellation Request handled by Wokebucks")
+							.WithUrl("https://github.com/chicklightning/WokebucksBot")
+							.WithCurrentTimestamp();
+
+				await ReplyAsync("", embed: embedBuilder.Build(), components: componentBuilder.Build());
+			}
+		}
+
+		[Command("tickets")]
+		[Summary("See all of the tickets you've opened.")]
+		public async Task GetTicketsAsync()
+		{
+
+		}
+
+		[Command("complaints")]
+		[Summary("See all of the tickets opened against you.")]
+		public async Task GetComplaintsAsync()
+		{
+
+		}
+
+		private async Task<bool> ReactIfSelfWhereNotAllowedAsync(IApplication application, SocketUser target, SocketUserMessage userMessage)
+		{
+			if (Context.User.Id != application.Owner.Id && string.Equals(Context.User.GetFullUsername(), target.GetFullUsername()))
+			{
+				var embedBuilder = new EmbedBuilder();
+				embedBuilder.WithColor(Color.Red);
+				embedBuilder.WithTitle("Invalid Bank Transaction");
+				embedBuilder.WithDescription("You can't cancel yourself ~~dumbass~~ it doesn't work like that.");
+				embedBuilder.WithFooter($"{Context.User.GetFullUsername()}'s Message provided by Wokebucks");
+				embedBuilder.WithUrl("https://github.com/chicklightning/WokebucksBot");
+				embedBuilder.WithCurrentTimestamp();
+
+				await ReplyAsync($"", false, embed: embedBuilder.Build());
+
+				var emote = _discordSocketClient.Guilds
+							.Where(x => x.Name == "The Swamp")
+							.SelectMany(x => x.Emotes)
+							.FirstOrDefault(x => x.Name.IndexOf(
+								"OofaDoofa", StringComparison.OrdinalIgnoreCase) != -1);
+				if (emote is not null)
+				{
+					await userMessage.AddReactionAsync(emote);
+				}
+
+				return true;
+			}
+
+			return false;
+		}
+
+		private Task RespondWithFormattedError(EmbedBuilder builder, string message)
+		{
+			builder.WithColor(Color.Red);
+			builder.WithTitle("Invalid Bank Transaction");
+			builder.WithDescription(message);
+			builder.WithFooter($"{Context.User.GetFullUsername()}'s Message provided by Wokebucks");
+			builder.WithCurrentTimestamp();
+			builder.WithUrl("https://github.com/chicklightning/WokebucksBot");
+
+			return ReplyAsync($"", false, embed: builder.Build());
+		}
+	}
+}

--- a/WokebucksBot/Bot/CommandModules/CancelModule.cs
+++ b/WokebucksBot/Bot/CommandModules/CancelModule.cs
@@ -61,7 +61,7 @@ namespace Swamp.WokebucksBot.Bot.CommandModules
 			if (ticket is not null && ticket.TicketOpened.AddDays(2) > DateTimeOffset.UtcNow)
 			{
 				await RespondWithFormattedError(embedBuilder, "You have to wait at least two (2) days before opening a new ticket against this user.");
-				_logger.LogError($"<{{{CommandName}}}> command failed for user <{{{UserIdKey}}}> targeting unknown user.", "cancel", Context.User.GetFullUsername());
+				_logger.LogError($"<{{{CommandName}}}> command failed for user <{{{UserIdKey}}}> since ticket from the last two days already exists for target.", "cancel", Context.User.GetFullUsername());
 				return;
 			}
 

--- a/WokebucksBot/Bot/DiscordClient.cs
+++ b/WokebucksBot/Bot/DiscordClient.cs
@@ -394,7 +394,7 @@ namespace Swamp.WokebucksBot.Bot
 				}
 
 				ticket.Votes.Add(component.User.Id.ToString());
-				ticket.Success = ticket.Votes.Count == 5;
+				ticket.Success = ticket.Votes.Count == 6;
 
 				var writeTasks = new List<Task>();
 				writeTasks.Add(_documentClient.UpsertDocumentAsync<CancelTicket>(ticket));

--- a/WokebucksBot/Bot/DiscordClient.cs
+++ b/WokebucksBot/Bot/DiscordClient.cs
@@ -202,7 +202,7 @@ namespace Swamp.WokebucksBot.Bot
 										.WithUrl("https://github.com/chicklightning/WokebucksBot")
 										.WithCurrentTimestamp();
 
-				writesToLotteriesAndUsers.Add(context.Channel.SendMessageAsync("", embed: embedBuilder.Build()));
+				writesToLotteriesAndUsers.Add(context.Channel.SendMessageAsync($"<@{winner.ID}>", embed: embedBuilder.Build()));
 
 				await Task.WhenAll(writesToLotteriesAndUsers);
 

--- a/WokebucksBot/Bot/DiscordClient.cs
+++ b/WokebucksBot/Bot/DiscordClient.cs
@@ -202,7 +202,7 @@ namespace Swamp.WokebucksBot.Bot
 										.WithUrl("https://github.com/chicklightning/WokebucksBot")
 										.WithCurrentTimestamp();
 
-				writesToLotteriesAndUsers.Add(context.Channel.SendMessageAsync("", allowedMentions: new AllowedMentions() { UserIds = new List<ulong>() { ulong.Parse(winner.ID) } }, embed: embedBuilder.Build()));
+				writesToLotteriesAndUsers.Add(context.Channel.SendMessageAsync("", embed: embedBuilder.Build()));
 
 				await Task.WhenAll(writesToLotteriesAndUsers);
 
@@ -438,7 +438,7 @@ namespace Swamp.WokebucksBot.Bot
 					announceEmbedBuilder.WithColor(Color.Red)
 										.WithTitle($"{ticket.TargetUsername} Has Been Cancelled")
 										.WithDescription($"Cancellation request initiated by {ticket.InitiatorUsername} has passed with six (6) votes.")
-										.AddField($"{ticket.TargetUsername}'s New Balance", "$" + string.Format("{0:0.00}", targetUser))
+										.AddField($"{ticket.TargetUsername}'s New Balance", "$" + string.Format("{0:0.00}", targetUser.Balance))
 										.WithFooter($"{ticket.InitiatorUsername}'s Cancel Ticket handled by Wokebucks")
 										.WithUrl("https://github.com/chicklightning/WokebucksBot")
 										.WithCurrentTimestamp();
@@ -455,12 +455,12 @@ namespace Swamp.WokebucksBot.Bot
 									 .WithUrl("https://github.com/chicklightning/WokebucksBot")
 									 .WithCurrentTimestamp();
 
-				messageTasks.Add(component.FollowupAsync("", ephemeral: true, allowedMentions: new AllowedMentions() { UserIds = new List<ulong>() { ulong.Parse(ticket.Target) } }, embed: ephemeralEmbedBuilder.Build()));
+				messageTasks.Add(component.FollowupAsync("", ephemeral: true, embed: ephemeralEmbedBuilder.Build()));
 				
 				// Send message to notify user of cancellation
 				if (announceEmbedBuilder is not null)
                 {
-					messageTasks.Add(component.Channel.SendMessageAsync("", embed: announceEmbedBuilder.Build()));
+					messageTasks.Add(component.Channel.SendMessageAsync($"@<{ticket.Target}>", embed: announceEmbedBuilder.Build()));
 				}
 
 				await Task.WhenAll(messageTasks);

--- a/WokebucksBot/Bot/DiscordClient.cs
+++ b/WokebucksBot/Bot/DiscordClient.cs
@@ -475,7 +475,7 @@ namespace Swamp.WokebucksBot.Bot
             {
 				_logger.LogInformation($"<{{{CommandName}}}> command invoked by user <{{{UserIdKey}}}>.", "seeticket", component.User.GetFullUsername());
 
-				string cancelTicketId = component.Data.CustomId.Replace("cancel", string.Empty);
+				string cancelTicketId = string.Join(", ", component.Data.Values);
 				CancelTicket ticket = await _documentClient.GetDocumentAsync<CancelTicket>(cancelTicketId) ?? throw new NullReferenceException($"Couldn't find cancel ticket with ID <{cancelTicketId}>.");
 
 				var embedBuilder = new EmbedBuilder();
@@ -489,7 +489,7 @@ namespace Swamp.WokebucksBot.Bot
 				embedBuilder.WithUrl("https://github.com/chicklightning/WokebucksBot");
 				embedBuilder.WithCurrentTimestamp();
 
-				await component.FollowupAsync("", ephemeral: true, embed: embedBuilder.Build());
+				await component.RespondAsync("", ephemeral: true, embed: embedBuilder.Build());
 			}
 			else
             {

--- a/WokebucksBot/Bot/DiscordClient.cs
+++ b/WokebucksBot/Bot/DiscordClient.cs
@@ -460,7 +460,7 @@ namespace Swamp.WokebucksBot.Bot
 				// Send message to notify user of cancellation
 				if (announceEmbedBuilder is not null)
                 {
-					messageTasks.Add(component.Channel.SendMessageAsync($"@<{ticket.Target}>", embed: announceEmbedBuilder.Build()));
+					messageTasks.Add(component.Channel.SendMessageAsync($"<@{ticket.Target}>", embed: announceEmbedBuilder.Build()));
 				}
 
 				await Task.WhenAll(messageTasks);
@@ -479,7 +479,7 @@ namespace Swamp.WokebucksBot.Bot
 				CancelTicket ticket = await _documentClient.GetDocumentAsync<CancelTicket>(cancelTicketId) ?? throw new NullReferenceException($"Couldn't find cancel ticket with ID <{cancelTicketId}>.");
 
 				var embedBuilder = new EmbedBuilder();
-				embedBuilder.WithColor(Color.Teal);
+				embedBuilder.WithColor(ticket.Success ? Color.Green : Color.Gold);
 				embedBuilder.WithTitle("Cancel Ticket");
 				embedBuilder.AddField("Plaintiff", ticket.InitiatorUsername);
 				embedBuilder.AddField("Defendant", ticket.TargetUsername);

--- a/WokebucksBot/CosmosDB/Models/Users/CancelTicket.cs
+++ b/WokebucksBot/CosmosDB/Models/Users/CancelTicket.cs
@@ -33,7 +33,7 @@ namespace Swamp.WokebucksBot.CosmosDB
         public bool Success { get; set; }
 
         // TODO: change to use datetime
-        public static string CreateGuidFromTicketInitiatorAndTarget(string initiatorId, string targetId)
+        public static string CreateDeterministicTicketGuid(string initiatorId, string targetId)
         {
             byte[] message = Encoding.UTF8.GetBytes(initiatorId + targetId);
             using var alg = SHA512.Create();
@@ -42,7 +42,7 @@ namespace Swamp.WokebucksBot.CosmosDB
             return new Guid(hashValue).ToString();
         }
 
-        public CancelTicket(SocketUser target, SocketUser initiator, string description) : base(CreateGuidFromTicketInitiatorAndTarget(initiator.Id.ToString(), target.Id.ToString()))
+        public CancelTicket(SocketUser target, SocketUser initiator, string description) : base(CreateDeterministicTicketGuid(initiator.Id.ToString(), target.Id.ToString()))
         {
             Votes = new HashSet<string>();
             TicketOpened = DateTimeOffset.UtcNow;
@@ -57,7 +57,7 @@ namespace Swamp.WokebucksBot.CosmosDB
         private CancelTicket()
         {
             Votes = new HashSet<string>();
-            TicketOpened = DateTimeOffset.UtcNow;
+            TicketOpened = DateTimeOffset.MinValue;
             Description = string.Empty;
             Initiator = string.Empty;
             InitiatorUsername = string.Empty;

--- a/WokebucksBot/CosmosDB/Models/Users/CancelTicket.cs
+++ b/WokebucksBot/CosmosDB/Models/Users/CancelTicket.cs
@@ -1,0 +1,68 @@
+﻿using Discord.WebSocket;
+using Newtonsoft.Json;
+using Swamp.WokebucksBot.Bot.Extensions;
+using System.Security.Cryptography;
+using System.Text;
+
+namespace Swamp.WokebucksBot.CosmosDB
+{
+    public class CancelTicket : IDocument
+    {
+        [JsonProperty(PropertyName = "votes", Required = Required.Always)]
+        public HashSet<string> Votes { get; set; }
+
+        [JsonProperty(PropertyName = "opened", Required = Required.Always)]
+        public DateTimeOffset TicketOpened { get; set; }
+
+        [JsonProperty(PropertyName = "desc", Required = Required.Always)]
+        public string Description { get; set; }
+
+        [JsonProperty(PropertyName = "init", Required = Required.Always)]
+        public string Initiator { get; set; }
+
+        [JsonProperty(PropertyName = "initUsername", Required = Required.Always)]
+        public string InitiatorUsername { get; set; }
+
+        [JsonProperty(PropertyName = "target", Required = Required.Always)]
+        public string Target { get; set; }
+
+        [JsonProperty(PropertyName = "targetUsername", Required = Required.Always)]
+        public string TargetUsername { get; set; }
+
+        [JsonProperty(PropertyName = "success", Required = Required.Always)]
+        public bool Success { get; set; }
+
+        // TODO: change to use datetime
+        public static string CreateGuidFromTicketInitiatorAndTarget(string initiatorId, string targetId)
+        {
+            byte[] message = Encoding.UTF8.GetBytes(initiatorId + targetId);
+            using var alg = SHA512.Create();
+            byte[] hashValue = alg.ComputeHash(message);
+            Array.Resize(ref hashValue, 16);
+            return new Guid(hashValue).ToString();
+        }
+
+        public CancelTicket(SocketUser target, SocketUser initiator, string description) : base(CreateGuidFromTicketInitiatorAndTarget(initiator.Id.ToString(), target.Id.ToString()))
+        {
+            Votes = new HashSet<string>();
+            TicketOpened = DateTimeOffset.UtcNow;
+            Description = description;
+            Initiator = initiator.Id.ToString();
+            InitiatorUsername = initiator.GetFullUsername();
+            Target = target.Id.ToString();
+            TargetUsername = target.GetFullUsername();
+        }
+
+        [JsonConstructor]
+        private CancelTicket()
+        {
+            Votes = new HashSet<string>();
+            TicketOpened = DateTimeOffset.UtcNow;
+            Description = string.Empty;
+            Initiator = string.Empty;
+            InitiatorUsername = string.Empty;
+            Target = string.Empty;
+            TargetUsername = string.Empty;
+        }
+    }
+}

--- a/WokebucksBot/CosmosDB/Models/Users/UserData.cs
+++ b/WokebucksBot/CosmosDB/Models/Users/UserData.cs
@@ -93,7 +93,7 @@ namespace Swamp.WokebucksBot.CosmosDB
         public void CancelUser(string transactionInitiator)
         {
             // If the user's balance is positive, reset it to 0; if the user's balance is negative, double it
-            double amount = (this.Balance >= 0) ? 0 : this.Balance * 2;
+            double amount = (this.Balance > 0) ? this.Balance * -1 : this.Balance;
 
             this.AddTransaction(transactionInitiator, "This person was canceled.", amount);
             this.AddToBalance(amount);

--- a/WokebucksBot/CosmosDB/Models/Users/UserData.cs
+++ b/WokebucksBot/CosmosDB/Models/Users/UserData.cs
@@ -1,6 +1,7 @@
 ﻿using Discord.WebSocket;
 using Newtonsoft.Json;
 using Swamp.WokebucksBot.Bot.Extensions;
+using System.Linq;
 
 namespace Swamp.WokebucksBot.CosmosDB
 {
@@ -21,6 +22,12 @@ namespace Swamp.WokebucksBot.CosmosDB
         [JsonProperty(PropertyName = "lvl", Required = Required.Always)]
         public uint Level { get; set; }
 
+        [JsonProperty(PropertyName = "cncl", Required = Required.Always)]
+        public IDictionary<string, string> CancelTickets { get; set; }
+
+        [JsonProperty(PropertyName = "tckts", Required = Required.Always)]
+        public IDictionary<string, string> CreatedTickets { get; set; }
+
         public UserData(SocketUser user) : base(user.Id.ToString())
         {
             Balance = 0;
@@ -28,6 +35,8 @@ namespace Swamp.WokebucksBot.CosmosDB
             TransactionLog = new List<Transaction>();
             Username = user.GetFullUsername();
             Level = uint.MinValue;
+            CancelTickets = new Dictionary<string, string>();
+            CreatedTickets = new Dictionary<string, string>();
         }
 
         [JsonConstructor]
@@ -38,6 +47,8 @@ namespace Swamp.WokebucksBot.CosmosDB
             TransactionLog = new List<Transaction>();
             Username = string.Empty;
             Level = uint.MinValue;
+            CancelTickets = new Dictionary<string, string>();
+            CreatedTickets = new Dictionary<string, string>();
         }
 
         public void UpdateUsernameAndAddToBalance(double amount, string username)
@@ -76,6 +87,33 @@ namespace Swamp.WokebucksBot.CosmosDB
             if (TransactionLog.Count > 10)
             {
                 TransactionLog = TransactionLog.OrderByDescending(x => x.TimeStamp).Take(10).ToList();
+            }
+        }
+
+        public void CancelUser(string transactionInitiator, string updatedUsername)
+        {
+            // If the user's balance is positive, reset it to 0; if the user's balance is negative, double it
+            double amount = (this.Balance >= 0) ? this.Balance * -1 : this.Balance;
+
+            this.AddTransaction(transactionInitiator, "This person was canceled.", amount);
+            this.UpdateUsernameAndAddToBalance(amount, updatedUsername);
+        }
+
+        public void AddCancelTicket(CancelTicket cancelTicket)
+        {
+            CancelTickets.Add(cancelTicket.ID, $"Started by {cancelTicket.InitiatorUsername} because \"{cancelTicket.Description}\".");
+            if (CancelTickets.Count > 10)
+            {
+                CancelTickets = CancelTickets.Take(10).ToDictionary(x => x.Key, x => x.Value);
+            }
+        }
+
+        public void AddCreatedTicket(CancelTicket createdTicket)
+        {
+            CreatedTickets.Add(createdTicket.ID, $"Started for {createdTicket.TargetUsername} because \"{createdTicket.Description}\".");
+            if (CreatedTickets.Count > 10)
+            {
+                CreatedTickets = CreatedTickets.Take(10).ToDictionary(x => x.Key, x => x.Value);
             }
         }
 

--- a/WokebucksBot/CosmosDB/Models/Users/UserData.cs
+++ b/WokebucksBot/CosmosDB/Models/Users/UserData.cs
@@ -90,31 +90,23 @@ namespace Swamp.WokebucksBot.CosmosDB
             }
         }
 
-        public void CancelUser(string transactionInitiator, string updatedUsername)
+        public void CancelUser(string transactionInitiator)
         {
             // If the user's balance is positive, reset it to 0; if the user's balance is negative, double it
-            double amount = (this.Balance >= 0) ? this.Balance * -1 : this.Balance;
+            double amount = (this.Balance >= 0) ? 0 : this.Balance * 2;
 
             this.AddTransaction(transactionInitiator, "This person was canceled.", amount);
-            this.UpdateUsernameAndAddToBalance(amount, updatedUsername);
+            this.AddToBalance(amount);
         }
 
         public void AddCancelTicket(CancelTicket cancelTicket)
         {
             CancelTickets.Add(cancelTicket.ID, $"Started by {cancelTicket.InitiatorUsername} because \"{cancelTicket.Description}\".");
-            if (CancelTickets.Count > 10)
-            {
-                CancelTickets = CancelTickets.Take(10).ToDictionary(x => x.Key, x => x.Value);
-            }
         }
 
         public void AddCreatedTicket(CancelTicket createdTicket)
         {
             CreatedTickets.Add(createdTicket.ID, $"Started for {createdTicket.TargetUsername} because \"{createdTicket.Description}\".");
-            if (CreatedTickets.Count > 10)
-            {
-                CreatedTickets = CreatedTickets.Take(10).ToDictionary(x => x.Key, x => x.Value);
-            }
         }
 
         public bool IsOverdrawn() => Balance < 0;


### PR DESCRIPTION
Lets a user create a cancellation ticket for another user. If the ticket receives 6 votes, the targeted user is cancelled. If they have a positive balance, it's reset to 0. If they have a negative balance, it's doubled. Users can vote on tickets whenever they want. Users can vote to cancel themselves, and users can vote on tickets they have opened. Users can create a new ticket against the same user after a 2 day wait period. Users can view all tickets opened against them and all tickets they have opened against others.